### PR TITLE
pari/gp for Windows

### DIFF
--- a/R/untb.R
+++ b/R/untb.R
@@ -795,7 +795,14 @@ fishers.alpha <- function(N, S, give=FALSE){
   pari_string <- paste(pari_string,"print(logKDAvec([", count.string, "]))")
   cat(pari_string, file = "logkda.gp")
   logkda.list <- shell(paste(gp_binary, "-q", "logkda.gp"), intern = TRUE)
-  logkda.list <- paste(logkda.list,sep="",collapse="")
+  # Eliminate the last item of the list that contains a prompt
+  if (is.list(logkda.list)) {
+    # pari/gp returned a list
+    logkda.list <- paste(logkda.list[[-length(logkda.list)]], sep = "", collapse = "")
+  } else {
+    # pari/gp returned a character vector
+    logkda.list <- paste(logkda.list[-length(logkda.list)], sep = "", collapse = "")
+  }
   
   if (numerical) {
     logkda.list <- (as.numeric(unlist(strsplit(gsub("\\[|\\]", "", logkda.list), ","))))

--- a/R/untb.R
+++ b/R/untb.R
@@ -783,13 +783,13 @@ fishers.alpha <- function(N, S, give=FALSE){
  "
 
   if (isTRUE(as.logical(Sys.info()[1] == "Windows"))) {
-    return(logkda_pari_windows(a, numerical, pari_string))
+    return(logkda_pari_windows(a, numerical, pari_string, gp_binary))
   } else {
     return(logkda_pari_unix(a, numerical, pari_string, gp_binary))
   }
 }
 
-"logkda_pari_windows" <- function (a, numerical, pari_string) {
+"logkda_pari_windows" <- function (a, numerical, pari_string, gp_binary) {
   a <- extant(as.count(a))
   count.string <- paste(as.vector(a), collapse = ",")
   pari_string <- paste(pari_string,"print(logKDAvec([", count.string, "]))")

--- a/R/untb.R
+++ b/R/untb.R
@@ -808,7 +808,7 @@ fishers.alpha <- function(N, S, give=FALSE){
     logkda.list <- (as.numeric(unlist(strsplit(gsub("\\[|\\]", "", logkda.list), ","))))
   }
   
-  shell("del logkda.gp")
+  file.remove("logkda.gp")
   return(logkda.list)
 }
 

--- a/R/untb.R
+++ b/R/untb.R
@@ -794,7 +794,7 @@ fishers.alpha <- function(N, S, give=FALSE){
   count.string <- paste(as.vector(a), collapse = ",")
   pari_string <- paste(pari_string,"print(logKDAvec([", count.string, "]))")
   cat(pari_string, file = "logkda.gp")
-  logkda.list <- shell("gp -q logkda", intern = TRUE)
+  logkda.list <- shell(paste(gp_binary, "-q", "logkda.gp"), intern = TRUE)
   logkda.list <- paste(logkda.list,sep="",collapse="")
   
   if (numerical) {


### PR DESCRIPTION
The function `logkda_pari_windows()` is not able to find gp binary because its path is lost between `logkda()` and it and because the output of `gp.exe` is not processed correctly.
This PR corrects three issues:

- It passes gp_binary from `logkda()` to the shell call of `gp.exe`: lines 786, 792 and 797.
- It deletes the last output of `gp.exe` that is not a number but the prompt "(hh:mm) gp >" where "hh:mm" is the current time. The output may be a vector or a list, so both cases are treated: lines 798:805.
- It replaces the shell call to `del` by R internal command `file.remove()`: line 811.

I tested the corrections under Windows 11, with pari/gp 2.17.2 64 bits, with the zoo dataset, to verify that the result is the same as that of `logkda.R()` and with the BCI dataset from vegan to check the results are indentical to those of [tetame](https://jeromechave.github.io/projects/tetame.htm), an independent implementation of Etienne's algorithm. The BCI dataset can't be processed by `logkda.R()`: after many minutes, the function returns an error.
